### PR TITLE
Add backend Lovense integration module and API endpoints

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "scipy>=1.17",
     "zstandard>=0.23",
     "pydantic-settings>=2.7",
+    "pylove",
 ]
 
 [project.scripts]

--- a/backend/telemu/api/lovense.py
+++ b/backend/telemu/api/lovense.py
@@ -1,0 +1,83 @@
+"""Lovense integration endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from telemu.lovense import (
+    LovenseClient,
+    LovenseClientError,
+    LovenseConnectRequest,
+    LovenseConnectionStatus,
+    LovenseFunctionRequest,
+    LovenseLanResolveRequest,
+)
+
+router = APIRouter(prefix="/lovense", tags=["lovense"])
+
+
+def _client(request: Request) -> LovenseClient:
+    client = getattr(request.app.state, "lovense", None)
+    if client is None:
+        raise HTTPException(status_code=500, detail="Lovense client is not initialized")
+    return client
+
+
+@router.get("/status", response_model=LovenseConnectionStatus)
+async def status(request: Request) -> LovenseConnectionStatus:
+    return LovenseConnectionStatus(**_client(request).status())
+
+
+@router.post("/connect", response_model=LovenseConnectionStatus)
+async def connect(body: LovenseConnectRequest, request: Request) -> LovenseConnectionStatus:
+    client = _client(request)
+    client.configure(domain=body.domain, https_port=body.https_port)
+    return LovenseConnectionStatus(**client.status())
+
+
+@router.post("/resolve-lan")
+async def resolve_lan(body: LovenseLanResolveRequest, request: Request) -> dict:
+    client = _client(request)
+    try:
+        result = await client.resolve_lan(token=body.token, uid=body.uid)
+    except LovenseClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return result
+
+
+@router.post("/get-toys")
+async def get_toys(request: Request) -> dict:
+    client = _client(request)
+    try:
+        result = await client.get_toys()
+    except LovenseClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return result
+
+
+@router.post("/function")
+async def function(body: LovenseFunctionRequest, request: Request) -> dict:
+    client = _client(request)
+    try:
+        result = await client.function(
+            action=body.action,
+            time_sec=body.time_sec,
+            toy=body.toy,
+            stop_previous=body.stop_previous,
+            loop_running_sec=body.loop_running_sec,
+            loop_pause_sec=body.loop_pause_sec,
+        )
+    except LovenseClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return result
+
+
+@router.post("/stop")
+async def stop(request: Request, toy: str = "") -> dict:
+    client = _client(request)
+    try:
+        result = await client.stop(toy=toy)
+    except LovenseClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return result
+

--- a/backend/telemu/config.py
+++ b/backend/telemu/config.py
@@ -29,6 +29,12 @@ class Settings(BaseSettings):
     # WebSocket
     ws_max_fps: int = 60
 
+    # Lovense integration
+    lovense_domain: str | None = None
+    lovense_https_port: int = 30010
+    lovense_verify_tls: bool = False
+    lovense_timeout_sec: float = 5.0
+
     # CORS (for development; Electron doesn't need this)
     cors_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
 

--- a/backend/telemu/lovense/__init__.py
+++ b/backend/telemu/lovense/__init__.py
@@ -1,0 +1,18 @@
+"""Lovense integration package."""
+
+from telemu.lovense.client import LovenseClient, LovenseClientError
+from telemu.lovense.models import (
+    LovenseConnectRequest,
+    LovenseConnectionStatus,
+    LovenseFunctionRequest,
+    LovenseLanResolveRequest,
+)
+
+__all__ = [
+    "LovenseClient",
+    "LovenseClientError",
+    "LovenseConnectRequest",
+    "LovenseConnectionStatus",
+    "LovenseFunctionRequest",
+    "LovenseLanResolveRequest",
+]

--- a/backend/telemu/lovense/client.py
+++ b/backend/telemu/lovense/client.py
@@ -1,0 +1,123 @@
+"""Lovense LAN API client.
+
+This module follows Lovense's documented developer/LAN flow:
+- Resolve a user's LAN endpoint via `https://api.lovense.com/api/lan/getToys`.
+- Send LAN commands to `https://{domain}:{https_port}/command`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import ssl
+from dataclasses import dataclass
+from urllib import error, request
+
+
+class LovenseClientError(RuntimeError):
+    """Raised when communication with Lovense endpoints fails."""
+
+
+@dataclass(slots=True)
+class LovenseConnection:
+    domain: str
+    https_port: int = 30010
+
+
+class LovenseClient:
+    """Client for Lovense developer and LAN APIs."""
+
+    def __init__(self, *, verify_tls: bool = False, timeout_sec: float = 5.0):
+        self.verify_tls = verify_tls
+        self.timeout_sec = timeout_sec
+        self.connection: LovenseConnection | None = None
+
+    def configure(self, domain: str, https_port: int = 30010) -> None:
+        self.connection = LovenseConnection(domain=domain.strip(), https_port=https_port)
+
+    def status(self) -> dict:
+        if self.connection is None:
+            return {
+                "configured": False,
+                "domain": None,
+                "https_port": None,
+                "verify_tls": self.verify_tls,
+            }
+        return {
+            "configured": True,
+            "domain": self.connection.domain,
+            "https_port": self.connection.https_port,
+            "verify_tls": self.verify_tls,
+        }
+
+    async def resolve_lan(self, token: str, uid: str) -> dict:
+        payload = {"token": token, "uid": uid}
+        return await asyncio.to_thread(
+            self._post_json,
+            "https://api.lovense.com/api/lan/getToys",
+            payload,
+        )
+
+    async def get_toys(self) -> dict:
+        return await self._lan_command({"command": "GetToys", "apiVer": 1})
+
+    async def function(
+        self,
+        *,
+        action: str,
+        time_sec: int = 0,
+        toy: str = "",
+        stop_previous: int = 1,
+        loop_running_sec: int = 0,
+        loop_pause_sec: int = 0,
+    ) -> dict:
+        payload = {
+            "command": "Function",
+            "action": action,
+            "timeSec": time_sec,
+            "toy": toy,
+            "stopPrevious": stop_previous,
+            "loopRunningSec": loop_running_sec,
+            "loopPauseSec": loop_pause_sec,
+            "apiVer": 1,
+        }
+        return await self._lan_command(payload)
+
+    async def stop(self, *, toy: str = "") -> dict:
+        return await self.function(action="Stop", toy=toy)
+
+    async def _lan_command(self, payload: dict) -> dict:
+        if self.connection is None:
+            raise LovenseClientError("Lovense LAN connection is not configured")
+        url = f"https://{self.connection.domain}:{self.connection.https_port}/command"
+        return await asyncio.to_thread(self._post_json, url, payload)
+
+    def _post_json(self, url: str, payload: dict) -> dict:
+        data = json.dumps(payload).encode("utf-8")
+        req = request.Request(
+            url=url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        context: ssl.SSLContext | None = None
+        if url.startswith("https://") and not self.verify_tls:
+            context = ssl._create_unverified_context()
+
+        try:
+            with request.urlopen(req, timeout=self.timeout_sec, context=context) as resp:
+                body = resp.read().decode("utf-8")
+                return json.loads(body) if body else {}
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise LovenseClientError(
+                f"Lovense HTTP {exc.code} for {url}: {detail or exc.reason}"
+            ) from exc
+        except error.URLError as exc:
+            raise LovenseClientError(f"Lovense connection error for {url}: {exc.reason}") from exc
+        except TimeoutError as exc:
+            raise LovenseClientError(f"Lovense request timed out for {url}") from exc
+        except json.JSONDecodeError as exc:
+            raise LovenseClientError(f"Lovense returned invalid JSON for {url}") from exc
+

--- a/backend/telemu/lovense/models.py
+++ b/backend/telemu/lovense/models.py
@@ -1,0 +1,32 @@
+"""Pydantic models for Lovense API integration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class LovenseConnectRequest(BaseModel):
+    domain: str = Field(min_length=1, description="Lovense LAN domain or host")
+    https_port: int = Field(default=30010, ge=1, le=65535)
+
+
+class LovenseLanResolveRequest(BaseModel):
+    token: str = Field(min_length=1, description="Lovense developer token")
+    uid: str = Field(min_length=1, description="Lovense user id")
+
+
+class LovenseFunctionRequest(BaseModel):
+    action: str = Field(min_length=1, description="Lovense Function action payload")
+    time_sec: int = Field(default=0, ge=0, le=3600)
+    toy: str = Field(default="", description="Optional toy id")
+    stop_previous: int = Field(default=1, ge=0, le=1)
+    loop_running_sec: int = Field(default=0, ge=0, le=3600)
+    loop_pause_sec: int = Field(default=0, ge=0, le=3600)
+
+
+class LovenseConnectionStatus(BaseModel):
+    configured: bool
+    domain: str | None = None
+    https_port: int | None = None
+    verify_tls: bool
+

--- a/backend/telemu/main.py
+++ b/backend/telemu/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from telemu import __version__
 from telemu.config import settings
+from telemu.lovense import LovenseClient
 from telemu.reader import DemoReader, TelemetryFrame, TelemetryReader
 from telemu.ws.manager import ConnectionManager
 from telemu.ws.router import manager as ws_manager
@@ -53,6 +54,13 @@ async def lifespan(app: FastAPI):
     app.state.reader = reader
     app.state.ws_manager = ws_manager
     app.state.db_conn = None
+    if not hasattr(app.state, "lovense"):
+        app.state.lovense = LovenseClient(
+            verify_tls=settings.lovense_verify_tls,
+            timeout_sec=settings.lovense_timeout_sec,
+        )
+        if settings.lovense_domain:
+            app.state.lovense.configure(settings.lovense_domain, settings.lovense_https_port)
 
     reader.subscribe(lambda frame: _schedule_broadcast(app, frame))
     await reader.start()
@@ -87,6 +95,12 @@ def create_app() -> FastAPI:
         version=__version__,
         lifespan=lifespan,
     )
+    app.state.lovense = LovenseClient(
+        verify_tls=settings.lovense_verify_tls,
+        timeout_sec=settings.lovense_timeout_sec,
+    )
+    if settings.lovense_domain:
+        app.state.lovense.configure(settings.lovense_domain, settings.lovense_https_port)
 
     # CORS
     app.add_middleware(
@@ -103,12 +117,14 @@ def create_app() -> FastAPI:
     from telemu.api.tables import router as tables_router
     from telemu.api.query import router as query_router
     from telemu.api.export import router as export_router
+    from telemu.api.lovense import router as lovense_router
 
     app.include_router(health_router, prefix="/api")
     app.include_router(sessions_router, prefix="/api")
     app.include_router(tables_router, prefix="/api")
     app.include_router(query_router, prefix="/api")
     app.include_router(export_router, prefix="/api")
+    app.include_router(lovense_router, prefix="/api")
     app.include_router(ws_router)
 
     return app

--- a/backend/tests/test_lovense_api.py
+++ b/backend/tests/test_lovense_api.py
@@ -1,0 +1,80 @@
+"""Tests for Lovense API endpoints."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from telemu.main import create_app
+
+
+class FakeLovenseClient:
+    def __init__(self):
+        self._status = {
+            "configured": False,
+            "domain": None,
+            "https_port": None,
+            "verify_tls": False,
+        }
+
+    def status(self):
+        return self._status
+
+    def configure(self, domain: str, https_port: int = 30010):
+        self._status = {
+            "configured": True,
+            "domain": domain,
+            "https_port": https_port,
+            "verify_tls": False,
+        }
+
+    async def resolve_lan(self, token: str, uid: str):
+        return {"code": 200, "message": "OK", "data": {"token": token, "uid": uid}}
+
+    async def get_toys(self):
+        return {"code": 200, "message": "OK", "data": {"toys": {}}}
+
+    async def function(self, **kwargs):
+        return {"code": 200, "message": "OK", "data": kwargs}
+
+    async def stop(self, *, toy: str = ""):
+        return {"code": 200, "message": "OK", "data": {"toy": toy}}
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    app = create_app()
+    app.state.lovense = FakeLovenseClient()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.anyio
+async def test_lovense_status(client):
+    resp = await client.get("/api/lovense/status")
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is False
+
+
+@pytest.mark.anyio
+async def test_lovense_connect(client):
+    resp = await client.post("/api/lovense/connect", json={"domain": "127-0-0-1.lovense.club"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["configured"] is True
+    assert data["domain"] == "127-0-0-1.lovense.club"
+
+
+@pytest.mark.anyio
+async def test_lovense_function(client):
+    resp = await client.post(
+        "/api/lovense/function",
+        json={"action": "Vibrate:5", "time_sec": 1},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["code"] == 200
+


### PR DESCRIPTION
## Summary
- add dedicated backend Lovense integration package under 	elemu/lovense
- add Lovense API endpoints under /api/lovense for status/connect/resolve/get-toys/function/stop
- wire Lovense client into app startup and config (TELEMU_LOVENSE_* settings)
- add backend tests for Lovense endpoints
- add pylove dependency via uv

## Scope
- backend only
- no frontend changes

## Validation
- uv run pytest (13 passed)