### PR TITLE
Add MkDocs External API section for Lovense integration

### DIFF
--- a/docs/docs/external-api/lovense.md
+++ b/docs/docs/external-api/lovense.md
@@ -1,0 +1,86 @@
+# Lovense Integration
+
+TeleMU includes backend-only Lovense support through a dedicated module and API routes.
+
+## What Was Added
+
+- `pylove` dependency in `backend/pyproject.toml` (managed with `uv`).
+- `telemu/lovense` package for Lovense API logic.
+- `/api/lovense/*` endpoints for integration control.
+- backend tests for Lovense API endpoints.
+
+## Configuration
+
+Environment variables:
+
+- `TELEMU_LOVENSE_DOMAIN` (optional): preconfigure LAN domain/host.
+- `TELEMU_LOVENSE_HTTPS_PORT` (default: `30010`)
+- `TELEMU_LOVENSE_VERIFY_TLS` (default: `false`)
+- `TELEMU_LOVENSE_TIMEOUT_SEC` (default: `5.0`)
+
+## API Endpoints
+
+All endpoints are served from the backend (`/api` prefix):
+
+- `GET /api/lovense/status`
+  - Returns configured connection status.
+- `POST /api/lovense/connect`
+  - Sets connection target (`domain`, optional `https_port`).
+- `POST /api/lovense/resolve-lan`
+  - Resolves user LAN details via Lovense developer API (`token`, `uid`).
+- `POST /api/lovense/get-toys`
+  - Requests toy/device list from configured Lovense LAN endpoint.
+- `POST /api/lovense/function`
+  - Sends Function commands (`action`, `time_sec`, optional toy/loop params).
+- `POST /api/lovense/stop`
+  - Sends a stop command (optional `toy` query param).
+
+## Quick Test Flow
+
+1. Start backend:
+
+```powershell
+cd backend
+uv run telemu
+```
+
+2. Resolve LAN endpoint:
+
+```powershell
+curl -X POST http://127.0.0.1:8000/api/lovense/resolve-lan `
+  -H "Content-Type: application/json" `
+  -d "{\"token\":\"YOUR_TOKEN\",\"uid\":\"YOUR_UID\"}"
+```
+
+3. Configure backend connection:
+
+```powershell
+curl -X POST http://127.0.0.1:8000/api/lovense/connect `
+  -H "Content-Type: application/json" `
+  -d "{\"domain\":\"YOUR_DOMAIN\",\"https_port\":30010}"
+```
+
+4. Verify toys:
+
+```powershell
+curl -X POST http://127.0.0.1:8000/api/lovense/get-toys
+```
+
+5. Send command:
+
+```powershell
+curl -X POST http://127.0.0.1:8000/api/lovense/function `
+  -H "Content-Type: application/json" `
+  -d "{\"action\":\"Vibrate:5\",\"time_sec\":2}"
+```
+
+## Validation
+
+From `backend/`:
+
+```powershell
+uv run pytest
+```
+
+This includes `tests/test_lovense_api.py`.
+

--- a/docs/docs/external-api/overview.md
+++ b/docs/docs/external-api/overview.md
@@ -1,0 +1,22 @@
+# External API Overview
+
+TeleMU exposes backend REST endpoints under `/api` for integrations that should not be implemented in the frontend.
+
+## Current Integrations
+
+- **Lovense API**: backend module for device discovery and command execution.
+
+## Design Rules
+
+1. External integrations live in dedicated backend modules (for example `telemu/lovense`).
+2. Public routes are mounted from `telemu/api/*` under `/api`.
+3. Frontend changes are optional and not required for backend integration support.
+4. Configuration is provided through `TELEMU_*` environment variables.
+
+## Backend Layout
+
+- `backend/telemu/lovense/client.py`: Lovense API client logic.
+- `backend/telemu/lovense/models.py`: request/response models.
+- `backend/telemu/api/lovense.py`: REST endpoints for integration operations.
+- `backend/telemu/main.py`: app wiring and router registration.
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -38,6 +38,9 @@ nav:
   - Streaming:
       - Overview: streaming/overview.md
       - Protocol Spec: streaming/protocol.md
+  - External API:
+      - Overview: external-api/overview.md
+      - Lovense Integration: external-api/lovense.md
   - Race Engineer:
       - Overview: race-engineer/overview.md
       - Tool Specs: race-engineer/tools.md


### PR DESCRIPTION
## Summary
- add new MkDocs `External API` section in navigation
- document backend external API structure and design rules
- add detailed Lovense integration docs for config, endpoints, and test flow

## Files
- `docs/mkdocs.yml`
- `docs/docs/external-api/overview.md`
- `docs/docs/external-api/lovense.md`

## Validation
- `uv run mkdocs build` from `docs/`
